### PR TITLE
Add Python compatibility flag

### DIFF
--- a/octoprint_macro/__init__.py
+++ b/octoprint_macro/__init__.py
@@ -51,6 +51,8 @@ class SidebarmacrosPlugin(octoprint.plugin.SettingsPlugin,
 				pip="https://github.com/mike1pol/octoprint_macro/archive/{target_version}.zip"
 			)
 		)
+	
+__plugin_pythoncompat__ = ">=2.7,<4"  # python 2 and 3
 
 def __plugin_load__():
 	global __plugin_implementation__


### PR DESCRIPTION
All tested, seems to work OK. No further changes were required.

Closes #11 

Once this is merged, the plugin repository can be updated to show compatibility & Python 3 users will be able to install this plugin. Nice work, btw.

If you want to test yourself on both Python 2 & 3 during development, then you will need multiple virtual environments. Details in the [documentation](https://docs.octoprint.org/en/master/plugins/python3_migration.html#how-to-get-a-python-3-virtual-environment-with-octoprint)